### PR TITLE
need the isDev flag to be available to push wp hot reloading assets

### DIFF
--- a/lib/modules/apostrophe-assets/index.js
+++ b/lib/modules/apostrophe-assets/index.js
@@ -14,6 +14,11 @@ module.exports = {
     }
   ],
   construct(self, options) {
+
+    self.on('apostrophe-pages:beforeSend', 'setIsDev', req => {
+      req.data.isDev = !(process.env.NODE_ENV === 'production');
+    });
+
     self.apos.app.get('/assets/css', function (req, res, next) {
       return options.minify
         ? res.rawRedirect(


### PR DESCRIPTION
This was removed on August 4th, I think inadvertently since the commit description doesn't mention it but @ValJed let me know if there was a reason I'm not aware of.